### PR TITLE
Bugfixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,3 +3,9 @@
 ## 1.0.0 (2019-01-27)
 
 -   initial release
+
+## 1.1.0 (2019-02-09)
+
+-   bugfix: Removed copy "reference" option for CompositeObject.
+-   bugfix: Clear method when using copy-on-write should not affect the original data.
+-   bugfix: Copy-on-write objects are garbage collected when deleted directly.

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,8 @@ export declare type CompositeObjectCopyMethod = "reference" | "on-write" | "keys
 export interface CompositeObjectOptions {
     /**
      * Indicates when CompositeObject or RecursiveObject key data passed to the constructor is copied.
-     * * "reference": Never copy key data, referencing the original data instead. The most performant option.
+     * * "reference": Never copy key data, referencing the original data instead. The most performant option. Only
+     * supported for copying a RecursiveObject.
      * * "on-write": Copy the data as necessary when changes are made. Incurs a performance pentalty, but preserves
      * the original data.
      * * "keys": Copy the key data. More performant than "on-write" when there are few entries, but less performant

--- a/index.js
+++ b/index.js
@@ -19,12 +19,12 @@ class CompositeObject {
                     break;
                 case "on-write":
                     // When using copy-on-write, map being copied must also use copy-on-write mode
-                    entries.copiedSet = new WeakSet();
-                    this.copiedSet = new WeakSet();
-                case "reference":
+                    this.copiedSet = entries.copiedSet = new WeakSet();
                     this.keyLength = entries.keyLength;
                     this.data = entries.data;
                     break;
+                case "reference":
+                    throw new Error(`Copy method '${copyMethod}' is not supported when copying CompositeObject`);
                 default:
                     throw new Error(`Unrecognized copy method '${copyMethod}'`);
             }
@@ -90,14 +90,17 @@ class CompositeObject {
     }
     clear() {
         this.data = {};
+        this.copiedSet = undefined;
         this.keyLength = 0;
     }
     delete(key) {
         if (!this.keyLength) {
+            this.clear();
             return false;
         }
         if (!key.length) {
             if (!hasProps(this.data)) {
+                this.clear();
                 return false;
             }
             this.clear();

--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
         "prepare": "npm run build",
         "build": "npm run clean && tsc && ts-node ts/scripts/update-typings.ts",
         "clean": "rm -rf index.js index.d.ts *.tgz",
-        "test": "npm run lint && nyc mocha --require ts-node/register ts/test/*.test.ts --reporter spec --colors",
+        "test": "npm run lint && nyc mocha --require ts-node/register ts/test/*.test.ts --colors",
         "test-package": "npm pack && cd test-package && npm i && npm test",
-        "bench": "node benchmark/index.js",
         "release": "np",
         "lint": "tslint ts/**/*.ts"
     },
@@ -34,7 +33,7 @@
     ],
     "dependencies": {},
     "devDependencies": {
-        "@types/chai": "4.1.7",
+        "@types/chai": "^4.1.7",
         "@types/mocha": "^5.2.5",
         "@types/node": "^10.12.18",
         "chai": "^4.2.0",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # composite-object
 
-A module for mapping between multi-part string keys and values.
+A module for mapping between multi-part string keys and values
 
 ## Install
 
@@ -50,7 +50,7 @@ Determines when the keys for the provided `CompositeObject` or `Object` are copi
 
 ###### `"reference"`
 
-Never copy keys. Changes made will affect the source.
+Never copy keys. Changes made will affect the source. Only supported for copying an `Object`.
 
 ###### `"on-write"`
 
@@ -169,7 +169,8 @@ const subObject: Record<MyStringEnum, string> = compositeObject.get(["key-part",
 
 ## Related
 
--   [composite-map](https://github.com/WesVanVugt/composite-map) - An Map-based implementation of this module
+-   [composite-map](https://github.com/WesVanVugt/composite-map) - A module for mapping between multi-part keys and values.
+-   [json-key-map](https://github.com/WesVanVugt/json-key-map) - A module for mapping between JSON keys and values.
 
 ## License
 

--- a/test-package/package.json
+++ b/test-package/package.json
@@ -9,13 +9,13 @@
         "postinstall": "cp ../*.tgz package.tgz && npm i package.tgz --no-save && npm run importtests",
         "importtests": "cp ../ts/test/*.test.ts ts/",
         "clean": "rm -rf ts/main.test.ts package.tgz && npm un composite-object",
-        "test": "npm run lint && mocha --require ts-node/register ts/*.test.ts --reporter spec --colors",
+        "test": "npm run lint && mocha --require ts-node/register ts/*.test.ts --colors",
         "lint": "tslint ts/**/*.ts"
     },
     "main": "index.js",
     "dependencies": {},
     "devDependencies": {
-        "@types/chai": "4.1.7",
+        "@types/chai": "^4.1.7",
         "@types/mocha": "^5.2.5",
         "@types/node": "^10.12.18",
         "chai": "^4.2.0",

--- a/test-package/ts/typing.test.ts
+++ b/test-package/ts/typing.test.ts
@@ -5,7 +5,7 @@ enum StringEnum {
     Two = "two",
 }
 
-describe("Typing Tests", () => {
+it("Typing Test", () => {
     const map = new CompositeObject2<"a", "b", boolean>();
     assertType<CompositeObject2<"a", "b", boolean>>(new CompositeObject2(map));
     assertType<CompositeObject2<"a", "b", boolean>>(new CompositeObject2(map.toJSON(), { keyLength: 2 }));

--- a/test-package/tsconfig.json
+++ b/test-package/tsconfig.json
@@ -1,6 +1,3 @@
 {
-    "extends": "../tsconfig",
-    "include": [
-        "ts/**/*.ts",
-    ],
+    "extends": "../tsconfig"
 }

--- a/ts/scripts/update-typings.ts
+++ b/ts/scripts/update-typings.ts
@@ -1,12 +1,11 @@
-// tslint:disable:no-console
 import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
 
 const DEFINITIONS_FILE = path.resolve(__dirname, "../../index.d.ts");
 
-function getRecursiveObjectTypes(count: number, keys: string[]): string {
-    return Array.from(new Array(count))
+function getRecursiveObjectTypes(keys: string[]): string {
+    return keys
         .map((_, i) => {
             if (!i) {
                 return "export declare type RecursiveObject1<K1 extends string, V> = {\n    [P in K1]?: V;\n}";
@@ -97,7 +96,7 @@ function main(): void {
 
     content =
         content.slice(0, firstIndex) +
-        getRecursiveObjectTypes(count, keys) +
+        getRecursiveObjectTypes(keys) +
         "\n" +
         getCompositeMapDefinitions(keys) +
         content.slice(lastIndex + 1);

--- a/ts/test/main.test.ts
+++ b/ts/test/main.test.ts
@@ -11,238 +11,11 @@ describe("CompositeObject", () => {
         (Object.prototype as any).__bad = true;
     });
 
-    it(".prototype.get(key)", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["a", "b"], "test").set(["b", "a"], "test2");
-        expect(map.get(["a", "b"])).to.equal("test");
-        expect(map.get(["b", "a"])).to.equal("test2");
-        expect(map.get(["a", "c"])).to.equal(undefined);
-    });
-
-    it(".prototype.has(key)", () => {
-        const map = new CompositeObject<string, boolean>();
-        map.set(["a", "b"], true);
-        expect(map.has(["a", "b"])).to.equal(true);
-        expect(map.has(["a", "c"])).to.equal(false);
-    });
-
-    it(".prototype.delete(key)", () => {
-        const map = new CompositeObject<string, boolean>();
-        map.set(["a", "b"], true);
-        expect(map.has(["a", "b"])).to.equal(true);
-        expect(map.delete(["a", "c"])).to.equal(false);
-        expect(map.delete(["a", "b"])).to.equal(true);
-        expect(map.has(["a", "b"])).to.equal(false);
-        expect(map.delete(["a", "b"])).to.equal(false);
-    });
-
-    it(".prototype.clear()", () => {
-        const map = new CompositeObject<string, boolean>();
-        map.set(["a", "b"], true);
-        expect(map.has(["a", "b"])).to.equal(true);
-        map.clear();
-        expect(map.has(["a", "b"])).to.equal(false);
-    });
-
-    it(".prototype.forEach((value, key) => {})", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["b", "a"], "test").set(["a", "b"], "test2");
-        const output: Array<[string[], string]> = [];
-
-        map.forEach((value, key) => {
-            output.push([key, value]);
-        });
-        expect(output).to.deep.equal([[["b", "a"], "test"], [["a", "b"], "test2"]]);
-    });
-
-    // To improve performance, if the key parameter is not accepted, separate code is run to avoid calculating the key
-    it(".prototype.forEach((value) => {})", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["b", "a"], "test").set(["a", "b"], "test2");
-        const output: string[] = [];
-
-        map.forEach((value) => {
-            output.push(value);
-        });
-        expect(output).to.deep.equal(["test", "test2"]);
-    });
-
-    it(".prototype.entries() / .prototype[@@iterator]()", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["a", "a", "a"], "test").set(["b", "a", "a"], "test2");
-        expect(Array.from(map)).to.deep.equal([[["a", "a", "a"], "test"], [["b", "a", "a"], "test2"]]);
-        expect(Array.from(map.entries())).to.deep.equal([[["a", "a", "a"], "test"], [["b", "a", "a"], "test2"]]);
-    });
-
-    it(".prototype.keys()", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["a", "a", "a"], "test").set(["b", "a", "a"], "test2");
-        expect(Array.from(map.keys())).to.deep.equal([["a", "a", "a"], ["b", "a", "a"]]);
-        map.clear();
-        map.set(["a"], "test").set(["b"], "test2");
-        expect(Array.from(map.keys())).to.deep.equal([["a"], ["b"]]);
-    });
-
-    it(".prototype.values()", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["a", "a", "a"], "test").set(["b", "a", "a"], "test2");
-        expect(Array.from(map.values())).to.deep.equal(["test", "test2"]);
-    });
-
     it("constructor(map)", () => {
         const map = new CompositeObject<string, string>();
         map.set(["a", "b"], "test");
         const mapCopy = new CompositeObject(map);
         expect(mapCopy.get(["a", "b"])).to.equal("test");
-    });
-
-    it(".prototype.set(long_key)", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["a", "b"], "test");
-        expect(() => map.set(["c", "d", "e"], "test2")).to.throw(/^Invalid key length$/);
-    });
-
-    it(".prototype.delete(long_key)", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["a", "b"], "test");
-        expect(() => map.delete(["c", "d", "e"])).to.throw(/^Invalid key length$/);
-    });
-
-    it(".prototype.has(long_key)", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["a", "b"], "test");
-        expect(() => map.has(["c", "d", "e"])).to.throw(/^Invalid key length$/);
-    });
-
-    it(".prototype.get(long_key)", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["a", "b"], "test");
-        expect(() => map.get(["c", "d", "e"])).to.throw(/^Invalid key length$/);
-    });
-
-    it(".prototype.has(short_key)", () => {
-        const map = new CompositeObject<string, boolean>();
-        map.set(["a", "b"], true);
-        expect(map.has(["a"])).to.equal(true);
-        expect(map.has(["b"])).to.equal(false);
-    });
-
-    it(".prototype.has(zero_length_key)", () => {
-        const map = new CompositeObject<string, boolean>();
-        expect(map.has([])).to.equal(false);
-        map.set(["a", "b"], true);
-        expect(map.has([])).to.equal(true);
-    });
-
-    it(".prototype.delete(short_key)", () => {
-        const map = new CompositeObject<string, boolean>();
-        map.set(["a", "b"], true).set(["a", "c"], true);
-        expect(map.delete(["a"])).to.equal(true);
-        expect(map.get(["a", "b"])).to.equal(undefined);
-        expect(map.get(["a", "c"])).to.equal(undefined);
-    });
-
-    it(".prototype.delete(zero_length_key)", () => {
-        const map = new CompositeObject<string, boolean>();
-        map.set(["a", "b"], true);
-        expect(map.delete([])).to.equal(true);
-        expect(map.get(["a", "b"])).to.equal(undefined);
-        expect(map.delete([])).to.equal(false);
-
-        // Try deleting root when the keyLength is non-zero
-        map.set(["a", "b"], true).delete(["a", "b"]);
-        expect(map.delete([])).to.equal(false);
-    });
-
-    it('constructor(map, { copy: "on-write" }), .prototype.set(key, value)', () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["a", "b"], "test")
-            .set(["b", "a"], "test2")
-            .set(["c", "a"], "test3");
-        expect((map as any).copiedSet).to.equal(undefined);
-        const mapCopy = new CompositeObject(map, { copy: "on-write" });
-
-        // Both the original and the copy should have a copiedSet
-        expect((map as any).copiedSet).to.be.a("WeakSet");
-        expect((mapCopy as any).copiedSet).to.be.a("WeakSet");
-        expect(mapCopy.get(["a", "b"])).to.equal("test");
-        expect(mapCopy.get([])).to.equal(map.get([]), "The unmodified copy should use the same root map object");
-
-        mapCopy.set(["a", "b"], "test4");
-        expect(mapCopy.get(["a", "b"])).to.equal("test4");
-        expect(map.get(["a", "b"])).to.equal("test", "The original map should remain unchanged");
-        const newRootMap = mapCopy.get([]);
-        expect(newRootMap).to.not.equal(map.get([]), "Changes should result in the root map being duplicated");
-        expect(mapCopy.get(["b"])).to.equal(map.get(["b"]), "The unmodified sub-map should still be shared");
-
-        mapCopy.set(["b", "a"], "test5");
-        expect(mapCopy.get([])).to.equal(newRootMap, "Further changes should not result in excess duplication");
-
-        map.set(["c", "a"], "test6");
-        expect(mapCopy.get(["c", "a"])).to.equal("test3", "Changes to the original map should not affect the copy");
-
-        const mapCopy2 = new CompositeObject(map, { copy: "on-write" });
-        map.set(["d", "a"], "test7");
-        expect(mapCopy2.get(["d", "a"])).to.equal(undefined);
-    });
-
-    it('constructor(map, { copy: "on-write" }), .prototype.delete(key)', () => {
-        const map = new CompositeObject<string, string>();
-        // Note: Unless a sub-map has multiple entries, pruning will cause the sub-map to remain unchanged since it
-        //   would instead be deleted by its parent.
-        map.set(["a", "a"], "test")
-            .set(["a", "b"], "test2")
-            .set(["b", "a"], "test3")
-            .set(["b", "b"], "test4");
-        const mapCopy = new CompositeObject(map, { copy: "on-write" });
-
-        expect(mapCopy.get(["a", "a"])).to.equal("test");
-        expect(mapCopy.get([])).to.equal(map.get([]), "The unmodified copy should use the same root map object");
-
-        expect(mapCopy.delete(["a", "a"])).to.equal(true);
-        expect(map.has(["a", "a"])).to.equal(true, "The original map should remain unchanged");
-        const newRootMap = mapCopy.get([]);
-        expect(newRootMap).to.not.equal(map.get([]), "Changes should result in the root map being duplicated");
-
-        expect(mapCopy.delete(["a", "b"])).to.equal(true);
-        expect(mapCopy.get([])).to.equal(newRootMap, "Further changes should not result in excess duplication");
-
-        expect(mapCopy.get(["b"])).to.equal(map.get(["b"]), "The unmodified sub-map should still be shared");
-        expect(map.delete(["b", "a"])).to.equal(true);
-        expect(mapCopy.has(["b", "a"])).to.equal(true, "Changes to the original map should not affect the copy");
-    });
-
-    it('constructor(map, { copy: "on-write" }), .prototype.delete(zero_length_key)', () => {
-        const map = new CompositeObject<string, string>();
-        // tslint:disable-next-line:no-unused-expression
-        new CompositeObject(map, { copy: "on-write" });
-
-        expect((map as any).copiedSet).to.be.a("WeakSet");
-        expect(map.delete([])).to.equal(false, "delete when the map has no keyLength");
-        expect((map as any).copiedSet).to.equal(undefined);
-
-        map.set(["a"], "test");
-        // tslint:disable-next-line:no-unused-expression
-        new CompositeObject(map, { copy: "on-write" });
-        expect((map as any).copiedSet).to.be.a("WeakSet");
-        delete (map.get([]) as RecursiveObject<string, string>).a;
-        expect(map.delete([])).to.equal(false, "delete when the map has a keyLength but no records");
-        expect((map as any).copiedSet).to.equal(undefined);
-    });
-
-    it('constructor(map, { copy: "on-write" }), .prototype.clear()', () => {
-        const map = new CompositeObject<string, string>();
-        // Note: Unless a sub-map has multiple entries, pruning will cause the sub-map to remain unchanged since it
-        //   would instead be deleted by its parent.
-        map.set(["a"], "test");
-        const mapCopy = new CompositeObject(map, { copy: "on-write" });
-
-        expect(map.has(["a"])).to.equal(true);
-        expect((map as any).copiedSet).to.be.a("WeakSet");
-        map.clear();
-        expect(map.has(["a"])).to.equal(false);
-        expect((map as any).copiedSet).to.equal(undefined);
-        expect(mapCopy.has(["a"])).to.equal(true);
     });
 
     it('constructor(map, { copy: "keys" })', () => {
@@ -287,40 +60,10 @@ describe("CompositeObject", () => {
         );
     });
 
-    it(".prototype.delete() [pruning]", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["a", "b", "c"], "test").set(["a", "c", "d"], "test2");
-
-        expect(map.get(["a", "b"])).to.not.equal(undefined);
-        map.delete(["a", "b", "c"]);
-        expect(map.get(["a", "b"])).to.equal(undefined);
-
-        expect(map.get(["a"])).to.not.equal(undefined);
-        map.delete(["a", "c", "d"]);
-        expect(map.get(["a"])).to.equal(undefined);
-    });
-
-    it(".prototype.get(short_key)", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["a", "b"], "test");
-        expect(map.get(["a"])).to.deep.equal({ b: "test" });
-        expect(map.get(["b"])).to.equal(undefined);
-    });
-
-    it(".prototype.get(zero_length_key)", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["a", "b"], "test");
-        expect(map.get([])).to.deep.equal({ a: { b: "test" } });
-    });
-
-    it(".prototype.toJSON()", () => {
-        const map = new CompositeObject<string, string>();
-        map.set(["a", "b"], "test").set(["b", "a"], "test2");
-        const json = jsonClone(map);
-        expect(json).to.deep.equal({
-            a: { b: "test" },
-            b: { a: "test2" },
-        });
+    it("constructor(entries)", () => {
+        expect(() => new CompositeObject<string, string>({}, undefined as any)).to.throw(
+            /^Object inputs require a non-zero value for options.keyLength$/,
+        );
     });
 
     it('constructor(entries, { copy: "keys", length: 2 })', () => {
@@ -361,10 +104,120 @@ describe("CompositeObject", () => {
         );
     });
 
-    it("constructor(entries)", () => {
-        expect(() => new CompositeObject<string, string>({}, undefined as any)).to.throw(
-            /^Object inputs require a non-zero value for options.keyLength$/,
-        );
+    it(".prototype.clear()", () => {
+        const map = new CompositeObject<string, boolean>();
+        map.set(["a", "b"], true);
+        expect(map.has(["a", "b"])).to.equal(true);
+        map.clear();
+        expect(map.has(["a", "b"])).to.equal(false);
+    });
+
+    it('.prototype.clear() [copy: "on-write"]', () => {
+        const map = new CompositeObject<string, string>();
+        // Note: Unless a sub-map has multiple entries, pruning will cause the sub-map to remain unchanged since it
+        //   would instead be deleted by its parent.
+        map.set(["a"], "test");
+        const mapCopy = new CompositeObject(map, { copy: "on-write" });
+
+        expect(map.has(["a"])).to.equal(true);
+        expect((map as any).copiedSet).to.be.a("WeakSet");
+        map.clear();
+        expect(map.has(["a"])).to.equal(false);
+        expect((map as any).copiedSet).to.equal(undefined);
+        expect(mapCopy.has(["a"])).to.equal(true);
+    });
+
+    it(".prototype.delete(key)", () => {
+        const map = new CompositeObject<string, boolean>();
+        map.set(["a", "b"], true);
+        expect(map.has(["a", "b"])).to.equal(true);
+        expect(map.delete(["a", "c"])).to.equal(false);
+        expect(map.delete(["a", "b"])).to.equal(true);
+        expect(map.has(["a", "b"])).to.equal(false);
+        expect(map.delete(["a", "b"])).to.equal(false);
+    });
+
+    it(".prototype.delete(long_key)", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["a", "b"], "test");
+        expect(() => map.delete(["c", "d", "e"])).to.throw(/^Invalid key length$/);
+    });
+
+    it(".prototype.delete(short_key)", () => {
+        const map = new CompositeObject<string, boolean>();
+        map.set(["a", "b"], true).set(["a", "c"], true);
+        expect(map.delete(["a"])).to.equal(true);
+        expect(map.get(["a", "b"])).to.equal(undefined);
+        expect(map.get(["a", "c"])).to.equal(undefined);
+    });
+
+    it(".prototype.delete(zero_length_key)", () => {
+        const map = new CompositeObject<string, boolean>();
+        map.set(["a", "b"], true);
+        expect(map.delete([])).to.equal(true);
+        expect(map.get(["a", "b"])).to.equal(undefined);
+        expect(map.delete([])).to.equal(false);
+
+        // Try deleting root when the keyLength is non-zero
+        map.set(["a", "b"], true).delete(["a", "b"]);
+        expect(map.delete([])).to.equal(false);
+    });
+
+    it('.prototype.delete(key) [copy: "on-write"]', () => {
+        const map = new CompositeObject<string, string>();
+        // Note: Unless a sub-map has multiple entries, pruning will cause the sub-map to remain unchanged since it
+        //   would instead be deleted by its parent.
+        map.set(["a", "a"], "test")
+            .set(["a", "b"], "test2")
+            .set(["b", "a"], "test3")
+            .set(["b", "b"], "test4");
+        const mapCopy = new CompositeObject(map, { copy: "on-write" });
+
+        expect(mapCopy.get(["a", "a"])).to.equal("test");
+        expect(mapCopy.get([])).to.equal(map.get([]), "The unmodified copy should use the same root map object");
+
+        expect(mapCopy.delete(["a", "a"])).to.equal(true);
+        expect(map.has(["a", "a"])).to.equal(true, "The original map should remain unchanged");
+        const newRootMap = mapCopy.get([]);
+        expect(newRootMap).to.not.equal(map.get([]), "Changes should result in the root map being duplicated");
+
+        expect(mapCopy.delete(["a", "b"])).to.equal(true);
+        expect(mapCopy.get([])).to.equal(newRootMap, "Further changes should not result in excess duplication");
+
+        expect(mapCopy.get(["b"])).to.equal(map.get(["b"]), "The unmodified sub-map should still be shared");
+        expect(map.delete(["b", "a"])).to.equal(true);
+        expect(mapCopy.has(["b", "a"])).to.equal(true, "Changes to the original map should not affect the copy");
+    });
+
+    it('.prototype.delete(zero_length_key) [copy: "on-write"]', () => {
+        const map = new CompositeObject<string, string>();
+        // tslint:disable-next-line:no-unused-expression
+        new CompositeObject(map, { copy: "on-write" });
+
+        expect((map as any).copiedSet).to.be.a("WeakSet");
+        expect(map.delete([])).to.equal(false, "delete when the map has no keyLength");
+        expect((map as any).copiedSet).to.equal(undefined);
+
+        map.set(["a"], "test");
+        // tslint:disable-next-line:no-unused-expression
+        new CompositeObject(map, { copy: "on-write" });
+        expect((map as any).copiedSet).to.be.a("WeakSet");
+        delete (map.get([]) as RecursiveObject<string, string>).a;
+        expect(map.delete([])).to.equal(false, "delete when the map has a keyLength but no records");
+        expect((map as any).copiedSet).to.equal(undefined);
+    });
+
+    it(".prototype.delete(key) [pruning]", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["a", "b", "c"], "test").set(["a", "c", "d"], "test2");
+
+        expect(map.get(["a", "b"])).to.not.equal(undefined);
+        map.delete(["a", "b", "c"]);
+        expect(map.get(["a", "b"])).to.equal(undefined);
+
+        expect(map.get(["a"])).to.not.equal(undefined);
+        map.delete(["a", "c", "d"]);
+        expect(map.get(["a"])).to.equal(undefined);
     });
 
     it(".prototype.delete(key) [while iterating]", () => {
@@ -390,5 +243,152 @@ describe("CompositeObject", () => {
         expect(values.next().value).to.equal("test");
         mapCopy.delete(["b", "a"]);
         expect(values.next().done).to.equal(true);
+    });
+
+    it(".prototype.entries() / .prototype[@@iterator]()", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["a", "a", "a"], "test").set(["b", "a", "a"], "test2");
+        expect(Array.from(map)).to.deep.equal([[["a", "a", "a"], "test"], [["b", "a", "a"], "test2"]]);
+        expect(Array.from(map.entries())).to.deep.equal([[["a", "a", "a"], "test"], [["b", "a", "a"], "test2"]]);
+    });
+
+    it(".prototype.forEach((value, key) => {})", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["b", "a"], "test").set(["a", "b"], "test2");
+        const output: Array<[string[], string]> = [];
+
+        map.forEach((value, key) => {
+            output.push([key, value]);
+        });
+        expect(output).to.deep.equal([[["b", "a"], "test"], [["a", "b"], "test2"]]);
+    });
+
+    // To improve performance, if the key parameter is not accepted, separate code is run to avoid calculating the key
+    it(".prototype.forEach((value) => {})", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["b", "a"], "test").set(["a", "b"], "test2");
+        const output: string[] = [];
+
+        map.forEach((value) => {
+            output.push(value);
+        });
+        expect(output).to.deep.equal(["test", "test2"]);
+    });
+
+    it(".prototype.get(key)", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["a", "b"], "test").set(["b", "a"], "test2");
+        expect(map.get(["a", "b"])).to.equal("test");
+        expect(map.get(["b", "a"])).to.equal("test2");
+        expect(map.get(["a", "c"])).to.equal(undefined);
+    });
+
+    it(".prototype.get(long_key)", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["a", "b"], "test");
+        expect(() => map.get(["c", "d", "e"])).to.throw(/^Invalid key length$/);
+    });
+
+    it(".prototype.get(short_key)", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["a", "b"], "test");
+        expect(map.get(["a"])).to.deep.equal({ b: "test" });
+        expect(map.get(["b"])).to.equal(undefined);
+    });
+
+    it(".prototype.get(zero_length_key)", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["a", "b"], "test");
+        expect(map.get([])).to.deep.equal({ a: { b: "test" } });
+    });
+
+    it(".prototype.has(key)", () => {
+        const map = new CompositeObject<string, boolean>();
+        map.set(["a", "b"], true);
+        expect(map.has(["a", "b"])).to.equal(true);
+        expect(map.has(["a", "c"])).to.equal(false);
+    });
+
+    it(".prototype.has(long_key)", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["a", "b"], "test");
+        expect(() => map.has(["c", "d", "e"])).to.throw(/^Invalid key length$/);
+    });
+
+    it(".prototype.has(short_key)", () => {
+        const map = new CompositeObject<string, boolean>();
+        map.set(["a", "b"], true);
+        expect(map.has(["a"])).to.equal(true);
+        expect(map.has(["b"])).to.equal(false);
+    });
+
+    it(".prototype.has(zero_length_key)", () => {
+        const map = new CompositeObject<string, boolean>();
+        expect(map.has([])).to.equal(false);
+        map.set(["a", "b"], true);
+        expect(map.has([])).to.equal(true);
+    });
+
+    it(".prototype.keys()", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["a", "a", "a"], "test").set(["b", "a", "a"], "test2");
+        expect(Array.from(map.keys())).to.deep.equal([["a", "a", "a"], ["b", "a", "a"]]);
+        map.clear();
+        map.set(["a"], "test").set(["b"], "test2");
+        expect(Array.from(map.keys())).to.deep.equal([["a"], ["b"]]);
+    });
+
+    it(".prototype.set(long_key)", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["a", "b"], "test");
+        expect(() => map.set(["c", "d", "e"], "test2")).to.throw(/^Invalid key length$/);
+    });
+
+    it('.prototype.set(key, value) [copy: "on-write"]', () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["a", "b"], "test")
+            .set(["b", "a"], "test2")
+            .set(["c", "a"], "test3");
+        expect((map as any).copiedSet).to.equal(undefined);
+        const mapCopy = new CompositeObject(map, { copy: "on-write" });
+
+        // Both the original and the copy should have a copiedSet
+        expect((map as any).copiedSet).to.be.a("WeakSet");
+        expect((mapCopy as any).copiedSet).to.be.a("WeakSet");
+        expect(mapCopy.get(["a", "b"])).to.equal("test");
+        expect(mapCopy.get([])).to.equal(map.get([]), "The unmodified copy should use the same root map object");
+
+        mapCopy.set(["a", "b"], "test4");
+        expect(mapCopy.get(["a", "b"])).to.equal("test4");
+        expect(map.get(["a", "b"])).to.equal("test", "The original map should remain unchanged");
+        const newRootMap = mapCopy.get([]);
+        expect(newRootMap).to.not.equal(map.get([]), "Changes should result in the root map being duplicated");
+        expect(mapCopy.get(["b"])).to.equal(map.get(["b"]), "The unmodified sub-map should still be shared");
+
+        mapCopy.set(["b", "a"], "test5");
+        expect(mapCopy.get([])).to.equal(newRootMap, "Further changes should not result in excess duplication");
+
+        map.set(["c", "a"], "test6");
+        expect(mapCopy.get(["c", "a"])).to.equal("test3", "Changes to the original map should not affect the copy");
+
+        const mapCopy2 = new CompositeObject(map, { copy: "on-write" });
+        map.set(["d", "a"], "test7");
+        expect(mapCopy2.get(["d", "a"])).to.equal(undefined);
+    });
+
+    it(".prototype.toJSON()", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["a", "b"], "test").set(["b", "a"], "test2");
+        const json = jsonClone(map);
+        expect(json).to.deep.equal({
+            a: { b: "test" },
+            b: { a: "test2" },
+        });
+    });
+
+    it(".prototype.values()", () => {
+        const map = new CompositeObject<string, string>();
+        map.set(["a", "a", "a"], "test").set(["b", "a", "a"], "test2");
+        expect(Array.from(map.values())).to.deep.equal(["test", "test2"]);
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,10 @@
         "module": "commonjs",
         "strict": true,
         "declaration": true,
+        "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
-        "esModuleInterop": true,
         "newLine": "LF",
         "outDir": ".",
         "lib": [
@@ -16,8 +16,7 @@
         ]
     },
     "include": [
-        "ts/index.ts",
-        "ts/typings/**/*"
+        "ts/index.ts"
     ],
     "exclude": []
 }


### PR DESCRIPTION
-   bugfix: Removed copy "reference" option for CompositeObject.
-   bugfix: Clear method when using copy-on-write should not affect the original data.
-   bugfix: Copy-on-write objects are garbage collected when deleted directly.